### PR TITLE
Client refactor: `UserPk` holds a `[u8; 32]` inside

### DIFF
--- a/common/src/api.rs
+++ b/common/src/api.rs
@@ -3,31 +3,78 @@ use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 
-pub const DEFAULT_USER_PK: UserPk = UserPk(1);
+use crate::hex::{self, FromHex};
+use crate::hexstr_or_bytes;
 
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, Serialize, Deserialize)]
-pub struct UserPk(i64);
+pub struct UserPk(#[serde(with = "hexstr_or_bytes")] [u8; 32]);
 
 impl UserPk {
-    pub fn new(inner: i64) -> Self {
+    pub const fn new(inner: [u8; 32]) -> Self {
         Self(inner)
     }
 
-    pub fn inner(&self) -> i64 {
+    pub fn inner(&self) -> [u8; 32] {
         self.0
+    }
+
+    /// Used to quickly construct `UserPk`s for tests.
+    pub fn from_i64(i: i64) -> Self {
+        // Convert i64 to [u8; 8]
+        let i_bytes = i.to_ne_bytes();
+
+        // Fill the first 8 bytes with the i64 bytes
+        let mut inner = [0u8; 32];
+        inner[0..8].clone_from_slice(&i_bytes);
+
+        Self(inner)
+    }
+
+    /// Used to compare inner `i64` values set during tests
+    pub fn to_i64(self) -> i64 {
+        let mut i_bytes = [0u8; 8];
+        i_bytes.clone_from_slice(&self.0[0..8]);
+        i64::from_ne_bytes(i_bytes)
     }
 }
 
 impl FromStr for UserPk {
-    type Err = anyhow::Error;
+    type Err = hex::DecodeError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let inner = i64::from_str(s)?;
-        Ok(Self(inner))
+        <[u8; 32]>::from_hex(s).map(Self::new)
     }
 }
 
 impl Display for UserPk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", hex::display(self.0.as_slice()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    const TEST_USER_PK: UserPk = UserPk::new(hex::decode_const(
+        b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    ));
+
+    #[test]
+    fn user_pk_consistent() {
+        let user_pk1 = UserPk::new(hex::decode_const(
+            b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        ));
+        let user_pk2 = UserPk::new(hex::decode_const(
+            b"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        ));
+        assert_eq!(user_pk1, user_pk2);
+    }
+
+    #[test]
+    fn user_pk_tostring_fromstr_round_trip() {
+        let user_pk1 = TEST_USER_PK;
+        let user_pk_str = user_pk1.to_string();
+        let user_pk2 = UserPk::from_str(&user_pk_str).unwrap();
+        assert_eq!(user_pk1, user_pk2);
     }
 }

--- a/node/src/api/mock.rs
+++ b/node/src/api/mock.rs
@@ -37,7 +37,7 @@ pub const HEX_SEED2: [u8; 32] = hex::decode_const(
 );
 
 fn node_pk(user_pk: UserPk) -> PublicKey {
-    match user_pk.inner() {
+    match user_pk.to_i64() {
         1 => PublicKey::from_slice(&NODE_PK1).unwrap(),
         2 => PublicKey::from_slice(&NODE_PK2).unwrap(),
         _ => todo!("TODO(max): Programmatically generate for new users"),
@@ -45,7 +45,7 @@ fn node_pk(user_pk: UserPk) -> PublicKey {
 }
 
 pub fn seed(user_pk: UserPk) -> Vec<u8> {
-    match user_pk.inner() {
+    match user_pk.to_i64() {
         1 => HEX_SEED1.to_vec(),
         2 => HEX_SEED2.to_vec(),
         _ => todo!("TODO(max): Programmatically generate for new users"),
@@ -195,7 +195,7 @@ impl VirtualFileSystem {
         let mut inner = HashMap::new();
 
         // Insert all directories used by the persister
-        let user_pk1 = UserPk::new(1);
+        let user_pk1 = UserPk::from_i64(1);
         let singleton_dir = DirectoryId {
             instance_id: instance_id(user_pk1),
             directory: persister::SINGLETON_DIRECTORY.into(),
@@ -213,7 +213,7 @@ impl VirtualFileSystem {
         inner.insert(channel_monitors_dir, HashMap::new());
 
         // Insert all directories used by the persister
-        let user_pk2 = UserPk::new(2);
+        let user_pk2 = UserPk::from_i64(2);
         let singleton_dir = DirectoryId {
             instance_id: instance_id(user_pk2),
             directory: persister::SINGLETON_DIRECTORY.into(),

--- a/node/src/command/test/mod.rs
+++ b/node/src/command/test/mod.rs
@@ -29,7 +29,7 @@ use crate::types::NetworkGraphType;
 
 /// Helper to return a default StartCommand struct for testing.
 fn default_args() -> StartCommand {
-    default_args_for_user(UserPk::new(1))
+    default_args_for_user(UserPk::from_i64(1))
 }
 
 fn default_args_for_user(user_pk: UserPk) -> StartCommand {
@@ -181,8 +181,8 @@ async fn list_channels() {
 /// Tests connecting two nodes to each other.
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn connect_peer() {
-    let args1 = default_args_for_user(UserPk::new(1));
-    let args2 = default_args_for_user(UserPk::new(2));
+    let args1 = default_args_for_user(UserPk::from_i64(1));
+    let args2 = default_args_for_user(UserPk::from_i64(2));
     let (node1, node2) = tokio::join!(
         CommandTestHarness::init(args1),
         CommandTestHarness::init(args2),
@@ -230,8 +230,8 @@ async fn connect_peer() {
 /// Tests opening a channel
 #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn open_channel() {
-    let mut args1 = default_args_for_user(UserPk::new(1));
-    let mut args2 = default_args_for_user(UserPk::new(2));
+    let mut args1 = default_args_for_user(UserPk::from_i64(1));
+    let mut args2 = default_args_for_user(UserPk::from_i64(2));
     args1.shutdown_after_sync_if_no_activity = true;
     args2.shutdown_after_sync_if_no_activity = true;
 

--- a/node/src/provision.rs
+++ b/node/src/provision.rs
@@ -85,7 +85,7 @@ struct RequestContext {
 /// The client sends this provisioning request to the node.
 #[derive(Serialize, Deserialize)]
 struct ProvisionRequest {
-    /// The client's user id.
+    /// The client's user pk.
     user_pk: UserPk,
     /// The client's node public key, derived from the root seed. The node
     /// should sanity check by re-deriving the node pk and checking that it
@@ -149,7 +149,7 @@ impl ProvisionedSecrets {
 //
 // ```json
 // {
-//   "user_pk": UserPk::new(123),
+//   "user_pk": UserPk::from_i64(123),
 //   "node_pk": "031355a4419a2b31c9b1ba2de0bcbefdd4a2ef6360f2b018736162a9b3be329fd4".parse().unwrap(),
 //   "root_seed": "86e4478f9f7e810d883f22ea2f0173e193904b488a62bb63764c82ba22b60ca7".parse().unwrap(),
 // }
@@ -188,7 +188,7 @@ async fn provision_request(
         enclave,
     };
 
-    // TODO(phlip9): auth using user id derived from root seed
+    // TODO(phlip9): auth using user pk derived from root seed
 
     ctx.api
         .create_node_instance_enclave(batch)
@@ -364,13 +364,13 @@ mod test {
     #[test]
     fn test_provision_request_serde() {
         let req = ProvisionRequest {
-            user_pk: UserPk::new(123),
+            user_pk: UserPk::from_i64(123),
             node_pk: "031355a4419a2b31c9b1ba2de0bcbefdd4a2ef6360f2b018736162a9b3be329fd4".parse().unwrap(),         root_seed:
         "86e4478f9f7e810d883f22ea2f0173e193904b488a62bb63764c82ba22b60ca7".parse().unwrap(),
         };
         let actual = serde_json::to_value(&req).unwrap();
         let expected = serde_json::json!({
-            "user_pk": UserPk::new(123),
+            "user_pk": UserPk::from_i64(123),
             "node_pk": "031355a4419a2b31c9b1ba2de0bcbefdd4a2ef6360f2b018736162a9b3be329fd4",
             "root_seed": "86e4478f9f7e810d883f22ea2f0173e193904b488a62bb63764c82ba22b60ca7",
         });
@@ -381,7 +381,7 @@ mod test {
     async fn test_provision() {
         logger::init_for_testing();
 
-        let user_pk = UserPk::new(123);
+        let user_pk = UserPk::from_i64(123);
         let node_dns_name = "localhost";
         let machine_id = enclave::machine_id();
         let measurement = enclave::measurement();


### PR DESCRIPTION
- `common::api::UserPk` changed its inner value from `i64` to `[u8; 32]`
- Updated usages throughout