### PR TITLE
run-sgx: fix broken tests in SGX. print symbols in backtraces.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
 dependencies = [
+ "flate2",
  "memchr",
 ]
 
@@ -1908,6 +1909,10 @@ dependencies = [
  "anyhow",
  "argh",
  "enclave-runner",
+ "memchr",
+ "object",
+ "once_cell",
+ "rustc-demangle",
  "serde",
  "sgx-isa",
  "sgxs-loaders",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ $ git clone https://github.com/lexe-tech/client
 $ cd client
 ```
 
+If running the node or running tests in SGX, install our runners:
+```bash
+$ cargo install --path run-sgx
+```
+
 ## Usage
 
 Run lints and tests

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -151,7 +151,12 @@ proptest = "1"
 sgx-panic-backtrace = "0.1"
 
 [package.metadata.fortanix-sgx]
-# stack size (in bytes) for each thread, the default stack size is 0x20000.
+# stack size (in bytes) for each thread, the default stack size is 0x20_000.
 stack-size=0x200_000
-# Gotcha: Don't forget to count the main thread when counting number of threads
-threads=4
+# The max number of threads we can spawn concurrently inside the SGX enclave.
+#
+# NOTE: ideally this value should be "threads=1", however, the current fortanix
+#       rust-sgx `async_usercalls` implementation requires an extra thread so
+#       until that changes, we're stuck with "threads=2".
+#       see: https://github.com/lexe-tech/rust-sgx/blob/70d11205fed08e49886bb25a1ea3df19928e8287/async-usercalls/src/queues.rs#L46
+threads=2

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -129,8 +129,10 @@ proptest = "1"
 [package.metadata.fortanix-sgx]
 # Stack size (in bytes) for each thread, the default stack size is 0x20000.
 stack-size=0x200000
-# Max # of threads. The node uses Tokio's current_thread rt so this is 1.
-
-# Don't forget to count the main thread when
-# counting the total number of threads.
-threads=1
+# The max number of threads we can spawn concurrently inside the SGX enclave.
+#
+# NOTE: ideally this value should be "threads=1", however, the current fortanix
+#       rust-sgx `async_usercalls` implementation requires an extra thread, so
+#       until that changes, we're stuck with "threads=2".
+#       see: https://github.com/lexe-tech/rust-sgx/blob/70d11205fed08e49886bb25a1ea3df19928e8287/async-usercalls/src/queues.rs#L46
+threads=2

--- a/run-sgx/Cargo.toml
+++ b/run-sgx/Cargo.toml
@@ -15,9 +15,21 @@ edition = "2021"
 anyhow = "1"
 # Derive-based command line argument parsing
 argh = "0.1"
+# Efficiently find newline byte in byte array
+memchr = "2"
+# For symbolizing backtrace frames from the enclave
+object = { version = "0.29", default-features = false, features = ["read_core", "compression", "elf"] }
+# Lazy init global
+once_cell = "1"
+# For demangling backtrace symbols into human-readable format
+rustc-demangle = "0.1"
 # Used to serialize / deserialize enclave config from Cargo.toml
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
+# Must match version in workspace exactly.
+tokio = { version = "=1.15.0", default-features = false, features = [
+    "net"
+] }
 
 [target.'cfg(all(target_arch = "x86_64", target_os = "linux"))'.dependencies]
 # --- PATCHED DEPENDENCIES --- #
@@ -33,6 +45,3 @@ enclave-runner = { version = "=0.5.1", default-features = false, features = ["cr
 # The base SGX types and platform intrinsics (for sealing, reports, etc...)
 sgx-isa = "=0.4.0"
 sgxs-loaders = "=0.3.3"
-tokio = { version = "=1.15.0", default-features = false, features = [
-    "net"
-] }

--- a/run-sgx/src/bin/run-sgx-cargo.rs
+++ b/run-sgx/src/bin/run-sgx-cargo.rs
@@ -175,6 +175,8 @@ impl Args {
         let mut run_sgx_cmd = Command::new("run-sgx");
         run_sgx_cmd
             .arg(&sgxs_bin_path)
+            .arg("--elf")
+            .arg(elf_bin_path)
             .arg("--")
             .args(self.enclave_args);
 

--- a/run-sgx/src/bin/run-sgx.rs
+++ b/run-sgx/src/bin/run-sgx.rs
@@ -1,5 +1,17 @@
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::pin::Pin;
+use std::str::{self, FromStr};
+use std::task::{ready, Context, Poll};
+use std::{fmt, mem};
+
 use anyhow::{format_err, Result};
 use argh::{EarlyExit, FromArgs, TopLevelCommand};
+use object::read::{SymbolMap, SymbolMapName};
+use object::Object;
+use once_cell::sync::OnceCell;
+use rustc_demangle::{demangle, Demangle};
+use tokio::io::AsyncWrite;
 
 #[derive(Debug)]
 pub struct Args {
@@ -19,10 +31,23 @@ pub struct Options {
     #[argh(positional)]
     pub bin: String,
 
-    /// path to the ".sig" enclave SIGSTRUCT file. defaults to the binary path
-    /// with ".sig" instead of ".sgxs" if unset.
-    #[argh(positional)]
+    // TODO(phlip9): figure out why this isn't working
+    /// optional path to the ".sig" enclave SIGSTRUCT file. defaults to the
+    /// binary path with ".sig" instead of ".sgxs" if unset.
+    #[argh(option)]
     pub sig: Option<String>,
+
+    /// optional path to the original elf binary, before going through the
+    /// ".sgxs" conversion.
+    ///
+    /// Used to symbolize raw backtrace addresses in the event of a panic.
+    ///
+    /// If unset, will attempt to use the ".sgxs" binary path without the
+    /// extension.
+    ///
+    /// If the file doesn't exist, backtraces just won't be symbolized.
+    #[argh(option)]
+    pub elf: Option<String>,
 }
 
 // -- impl Args -- //
@@ -31,7 +56,6 @@ impl Args {
     // Can only load real enclaves on x86_64-unknown-linux
     #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
     pub fn run(self) -> Result<()> {
-        // use std::path::{Path, PathBuf};
         use std::path::Path;
 
         use aesm_client::AesmClient;
@@ -48,6 +72,15 @@ impl Args {
             .build();
 
         let bin_path = Path::new(&self.opts.bin);
+        let maybe_elf_bin_path =
+            self.opts.elf.as_ref().map(PathBuf::from).or_else(|| {
+                let elf = bin_path.with_extension("");
+                if elf.exists() {
+                    Some(elf)
+                } else {
+                    None
+                }
+            });
         let mut enclave = EnclaveBuilder::new(bin_path);
 
         // problem: enclave can't talk to the AESM (fs access denied).
@@ -71,11 +104,15 @@ impl Args {
         // attach the enclave's args
         enclave.args(self.enclave_args);
 
-        // TODO(phlip9): get this working again
-        // // hook stdout so we can symbolize backtraces
-        // let stdout = tokio02::io::stdout();
-        // let stdout = backtrace_symbolizer_stream(stdout);
-        // enclave.stdout(stdout);
+        // hook stdout so we can symbolize backtraces
+        if let Some(elf_bin_path) = maybe_elf_bin_path {
+            ENCLAVE_ELF_BIN_PATH.set(elf_bin_path).expect(
+                "ENCLAVE_ELF_BIN_PATH should never be set more than once",
+            );
+            let stdout = tokio::io::stdout();
+            let stdout = backtrace_symbolizer_stream(stdout);
+            enclave.stdout(stdout);
+        }
 
         // // TODO(phlip9): for some reason, this causes the runner to hang if
         // the enclave ever panics...
@@ -132,6 +169,293 @@ fn split_args<'a>(args: &'a [&'a str]) -> (&'a [&'a str], &'a [&'a str]) {
     }
 }
 
+// -- impl AsyncLineWriter -- //
+
+/// Buffers writes until we hit a newline, then calls a callback on the line
+/// before writing the modified line into the wrapped [`AsyncWrite`].
+pub struct AsyncLineWriter<W, F> {
+    inner: W,
+    buf: Vec<u8>,
+    line_callback: F,
+    need_flush: bool,
+    write_offset: usize,
+}
+
+impl<W, F> AsyncLineWriter<W, F>
+where
+    W: AsyncWrite + Unpin,
+    F: Fn(Vec<u8>) -> Vec<u8> + Unpin,
+{
+    pub fn new(inner: W, line_callback: F) -> Self {
+        Self {
+            inner,
+            buf: Vec::with_capacity(8192),
+            line_callback,
+            need_flush: false,
+            write_offset: 0,
+        }
+    }
+
+    /// Try to write the buffered (and maybe modified) line, `self.buf`, into
+    /// the underlying [`AsyncWrite`]. We won't accept more input until this
+    /// pending write is complete.
+    fn poll_write_pending(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        if !self.need_flush {
+            return Poll::Ready(Ok(()));
+        }
+
+        let write_buf = &self.buf[self.write_offset..];
+        if write_buf.is_empty() {
+            self.need_flush = false;
+            return Poll::Ready(Ok(()));
+        }
+
+        let bytes_written = match Pin::new(&mut self.inner)
+            .poll_write(cx, &self.buf[self.write_offset..])
+        {
+            Poll::Pending => return Poll::Pending,
+            Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+            Poll::Ready(Ok(bytes_written)) => bytes_written,
+        };
+
+        self.write_offset += bytes_written;
+
+        // we've written all the pending bytes. reset.
+        if self.write_offset == self.buf.len() {
+            self.need_flush = false;
+            self.write_offset = 0;
+            self.buf.clear();
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl<W, F> AsyncWrite for AsyncLineWriter<W, F>
+where
+    W: AsyncWrite + Unpin,
+    F: Fn(Vec<u8>) -> Vec<u8> + Unpin,
+{
+    /// 1. first try to flush any pending write we might have buffered
+    /// 2. accept and buffer more bytes from the input until we see a '\n'
+    /// 3. notify the callback of a new line, which they might modify
+    /// 4. move into flush mode to write the buffered, modified line before
+    ///    accepting more input.
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        // finish writing any pending writes first.
+        ready!(self.poll_write_pending(cx))?;
+
+        // buffer until we find a newline byte
+        let newline_idx = memchr::memchr(b'\n', buf);
+        let newline_idx = match newline_idx {
+            None => {
+                // no newline byte yet, just keep buffering
+                self.buf.extend_from_slice(buf);
+                return Poll::Ready(Ok(buf.len()));
+            }
+            Some(newline_idx) => newline_idx,
+        };
+
+        // we'll only write up to and including the newline
+        let buf = &buf[..newline_idx + 1];
+        let bytes_written = buf.len();
+
+        // copy line into buf
+        self.buf.extend_from_slice(buf);
+
+        // notify the caller of the new line, they can modify it if they wish.
+        let buf = mem::take(&mut self.buf);
+        self.buf = (self.line_callback)(buf);
+
+        // set mode to flush pending write
+        self.need_flush = true;
+        self.write_offset = 0;
+
+        Poll::Ready(Ok(bytes_written))
+    }
+
+    fn poll_flush(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        ready!(self.poll_write_pending(cx))?;
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}
+
+// -- impl Backtrace -- //
+
+#[derive(Debug)]
+struct BacktraceFrame {
+    frame_idx: usize,
+    instruction_ptr: usize,
+    symbol_name: Option<Demangle<'static>>,
+}
+
+impl BacktraceFrame {
+    fn parse_from_backtrace_line(line: &str) -> Option<Self> {
+        // just some quick and dirty parsing code
+
+        // example backtrace line:
+        // "  11: 0x3933f\n"
+
+        fn parse_hex(s: &str) -> Option<usize> {
+            usize::from_str_radix(s, 16).ok()
+        }
+
+        let (frame_idx, rest) =
+            line.split_once(": ").and_then(|(prefix, rest)| {
+                let prefix = prefix.trim_start();
+                let frame_idx = usize::from_str(prefix).ok()?;
+                Some((frame_idx, rest))
+            })?;
+
+        let instruction_ptr =
+            rest.trim_end().strip_prefix("0x").and_then(parse_hex)?;
+
+        Some(Self {
+            frame_idx,
+            instruction_ptr,
+            symbol_name: None,
+        })
+    }
+}
+
+impl fmt::Display for BacktraceFrame {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let idx = self.frame_idx;
+        let ip = self.instruction_ptr;
+
+        write!(f, "{idx:>4}: ip={ip:#x}")?;
+        if let Some(symbol_name) = &self.symbol_name {
+            write!(f, " : {symbol_name:#}")?;
+        }
+        Ok(())
+    }
+}
+
+/// A stream that symbolizes backtrace lines. When we see a backtrace line,
+/// try to symbolize the line (convert the raw addresses to human-readable
+/// symbols).
+pub fn backtrace_symbolizer_stream<W: AsyncWrite + Unpin>(
+    stream: W,
+) -> impl AsyncWrite + Unpin {
+    AsyncLineWriter::new(stream, move |mut line_buf| {
+        // quickly avoid processing long lines, which definitely aren't
+        // backtrace frames
+        if line_buf.len() >= 32 {
+            return line_buf;
+        }
+
+        // only parse utf8-encoded lines
+        let line_str = match str::from_utf8(&line_buf) {
+            Ok(s) => s,
+            Err(_) => return line_buf,
+        };
+
+        // try to parse a backtrace frame from this line
+        let mut frame =
+            match BacktraceFrame::parse_from_backtrace_line(line_str) {
+                Some(frame) => frame,
+                None => return line_buf,
+            };
+
+        // we found a backtrace frame, try to lazily load the elf binary and
+        // extract the symbol table
+        //
+        // 1. Try to resolve the symbol name.
+        // 2. The symbol name comes out mangled, e.g.
+        //    "_ZN11sgx_enclave4main17h26101c5064988311E", so we need to
+        //    demangle to make it pretty, like "sgx_enclave::main".
+        frame.symbol_name = enclave_elf_symbol_map()
+            .get(frame.instruction_ptr as u64)
+            .map(|symbol| demangle(symbol.name()));
+
+        // in the current line, replace the raw backtrace frame with the
+        // symbolized version.
+        line_buf.clear();
+        writeln!(&mut line_buf, "{}", frame)
+            .expect("Formatting into a Vec<u8> should never fail");
+        line_buf
+    })
+}
+
+// -- lazy load symbol map -- //
+
+fn io_err_other<E>(err: E) -> io::Error
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    io::Error::new(io::ErrorKind::Other, err)
+}
+
+// The symbol names that `object` parses from a binary are just references to
+// parts of the binary, so they can't live longer than the binary itself. This
+// is significantly easier if all the lifetimes are 'static, so we just stuff
+// these intermediate values into global `OnceCell`s.
+
+static ENCLAVE_ELF_BIN_PATH: OnceCell<PathBuf> = OnceCell::new();
+
+fn enclave_elf_bin_bytes() -> io::Result<&'static [u8]> {
+    static ENCLAVE_ELF_BIN_BYTES: OnceCell<Vec<u8>> = OnceCell::new();
+
+    ENCLAVE_ELF_BIN_BYTES
+        .get_or_try_init(|| -> io::Result<Vec<u8>> {
+            let path = ENCLAVE_ELF_BIN_PATH
+                .get()
+                .ok_or_else(|| io_err_other("ENCLAVE_ELF_BIN_PATH not set"))?;
+            std::fs::read(path).map_err(|err| {
+                eprintln!("run-sgx: error reading enclave elf binary: {err}");
+                err
+            })
+        })
+        .map(Vec::as_slice)
+}
+
+fn enclave_elf_object(
+) -> io::Result<&'static object::File<'static, &'static [u8]>> {
+    static ENCLAVE_ELF_OBJECT: OnceCell<object::File<'static, &'static [u8]>> =
+        OnceCell::new();
+
+    ENCLAVE_ELF_OBJECT.get_or_try_init(|| {
+        let bytes = enclave_elf_bin_bytes()?;
+        object::File::parse(bytes)
+            .map_err(|err| {
+                eprintln!("run-sgx: error parsing enclave elf binary as an elf object: {err}");
+                io::Error::new(io::ErrorKind::Other, err)
+            })
+    })
+}
+
+fn enclave_elf_symbol_map() -> &'static SymbolMap<SymbolMapName<'static>> {
+    static ENCLAVE_ELF_SYMBOL_MAP: OnceCell<SymbolMap<SymbolMapName<'static>>> =
+        OnceCell::new();
+
+    ENCLAVE_ELF_SYMBOL_MAP.get_or_init(|| {
+        enclave_elf_object()
+            .map(|obj| obj.symbol_map())
+            // just return an empty symbol map if there was some error
+            // reading or parsing the elf binary
+            .unwrap_or_else(|_| SymbolMap::new(Vec::new()))
+    })
+}
+
+// -- main -- //
+
 fn main() {
     // Note: can't just use `argh::from_env` here b/c we need to parse out the
     // enclave args after the "--"
@@ -142,5 +466,25 @@ fn main() {
     if let Err(err) = result {
         eprintln!("run-sgx error: {err:#}");
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_parse_backtrace_frame() {
+        let frame = BacktraceFrame::parse_from_backtrace_line("  43: 0x2f648a")
+            .unwrap();
+        assert_eq!(frame.frame_idx, 43);
+        assert_eq!(frame.instruction_ptr, 0x2f648a);
+
+        assert!(BacktraceFrame::parse_from_backtrace_line("").is_none());
+        assert!(BacktraceFrame::parse_from_backtrace_line("foo bar").is_none());
+        assert!(BacktraceFrame::parse_from_backtrace_line(
+            "enclave panic: panicked at 'failed to spawn thread: Os'"
+        )
+        .is_none());
     }
 }


### PR DESCRIPTION
* some of the tests were broken in SGX, since `node` had `threads=1` set in its `Cargo.toml`. Apparently the current `async_usercalls` impl in `rust-sgx` always spawns an extra thread to handle usercall returns or something. Unless that changes, we'll need at least `threads=2` in all SGX crates.
* In the process of debugging this issue, I also ported over the automatic backtrace symbolizer setup I had previously. Now backtraces are actually useful! Best of all, you don't have to configure anything. It Just Works™

## before

```
enclave panic: panicked at 'failed to spawn thread: Os { code: 11, kind: WouldBlock, message: "operation would block" }', /rustc/2019147c5642c08cdb9ad4cacd97dd1fa4ffa701/library/std/src/thread/mod.rs:665:29
stack backtrace:
   0: 0x35e909
   1: 0x35e486
   2: 0x35e86c
   3: 0xa536cb
   4: 0xa534c0
   5: 0xa512af
   6: 0xa531ce
   7: 0xa6da72
   8: 0xa6dd72
   9: 0x961eac
  10: 0x952331
  ..
```

## after

```
enclave panic: panicked at 'failed to spawn thread: Os { code: 11, kind: WouldBlock, message: "operation would block" }', /rustc/2019147c5642c08cdb9ad4cacd97dd1fa4ffa701/library/std/src/thread/mod.rs:665:29
stack backtrace:
   0: ip=0x35e909 : backtrace::backtrace::trace_unsynchronized
   1: ip=0x35e486 : sgx_panic_backtrace::print_backtrace_frames
   2: ip=0x35e86c : sgx_panic_backtrace::set_panic_hook::{{closure}}
   3: ip=0xa536cb : std::panicking::rust_panic_with_hook
   4: ip=0xa534c0 : std::panicking::begin_panic_handler::{{closure}}
   5: ip=0xa512af : std::sys_common::backtrace::__rust_end_short_backtrace
   6: ip=0xa531ce : rust_begin_unwind
   7: ip=0xa6da72 : core::panicking::panic_fmt
   8: ip=0xa6dd72 : core::result::unwrap_failed
   9: ip=0x961eac : core::result::Result<T,E>::expect
  10: ip=0x952331 : std::thread::spawn
  ..
```