### PR TITLE
shutdown: use at-most-once semantics for `shutdown.recv()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +486,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-rustls",
+ "tokio-test",
  "tracing",
  "warp",
  "webpki 0.22.0",
@@ -2521,6 +2543,19 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tokio-test"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53474327ae5e166530d17f2d956afcb4f8a004de581b3cae10f12006bc8163e3"
+dependencies = [
+ "async-stream",
+ "bytes",
+ "futures-core",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -141,6 +141,8 @@ proptest-derive = "0.3"
 serde_json = "1"
 # lower-level async TLS interface
 tokio-rustls = { version = "0.23", default-features = false }
+# Utilities for testing futures
+tokio-test = "0.4"
 
 [target.'cfg(not(target_env = "sgx"))'.dev-dependencies]
 # Include additional useful proptest features when testing outside of SGX

--- a/common/src/shutdown.rs
+++ b/common/src/shutdown.rs
@@ -6,7 +6,9 @@ use tokio::sync::Semaphore;
 ///
 /// Features:
 ///
-/// - Multi-producer and multi-consumer - simply clone to get another handle
+/// - Multi-producer and multi-consumer - simply clone to get another handle.
+/// - Every clone observes shutdown signals at-most-once. If the shutdown has
+///   already been sent, new clones can still observe it once.
 /// - Consumers can receive shutdown signals that were sent prior to
 ///   'subscribing' to the channel (unlike [`tokio::sync::broadcast`]);
 /// - It is safe to send a shutdown signal multiple times (e.g. by accident).
@@ -20,9 +22,10 @@ use tokio::sync::Semaphore;
 ///
 /// [`acquire`]: Semaphore::acquire
 /// [`AcquireError`]: tokio::sync::AcquireError
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct ShutdownChannel {
     inner: Arc<Semaphore>,
+    have_recved: bool,
 }
 
 impl ShutdownChannel {
@@ -31,7 +34,10 @@ impl ShutdownChannel {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let inner = Arc::new(Semaphore::new(0));
-        Self { inner }
+        Self {
+            inner,
+            have_recved: false,
+        }
     }
 
     /// Send a shutdown signal, causing all actors waiting on this channel to
@@ -39,17 +45,29 @@ impl ShutdownChannel {
     ///
     /// [`recv`]: ShutdownChannel::recv
     pub fn send(&self) {
-        self.inner.close()
+        self.inner.close();
     }
 
     /// Wait for a shutdown signal.
-    /// If a shutdown signal was already sent, this fn returns immediately.
-    pub async fn recv(&self) {
-        self.inner
-            .acquire()
-            .await
-            .map_err(|_| ())
-            .expect_err("Shouldn't've been able to acquire a permit")
+    ///
+    /// If this `ShutdownChannel` has already observed a shutdown, _this future
+    /// will never return!_
+    pub async fn recv(&mut self) {
+        if self.have_recved {
+            // TODO(phlip9): seems not great, but it works with what we have
+            // THIS FUTURE WILL NEVER RESOLVE
+            std::future::pending().await
+        } else {
+            // wait for a shutdown
+            self.inner
+                .acquire()
+                .await
+                .map_err(|_| ())
+                .expect_err("Shouldn't've been able to acquire a permit");
+            // we've seen a shutdown; if this method gets called again, it
+            // won't yield.
+            self.have_recved = true;
+        }
     }
 
     /// Immediately returns whether a shutdown signal has been sent.
@@ -58,11 +76,23 @@ impl ShutdownChannel {
     }
 }
 
+impl Clone for ShutdownChannel {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            // Every clone gets a chance to see the shutdown, even if the clonee
+            // handle has already seen it.
+            have_recved: false,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::time::Duration;
 
     use tokio::time;
+    use tokio_test::{assert_pending, assert_ready};
 
     use super::*;
 
@@ -74,11 +104,45 @@ mod test {
         shutdown.send();
     }
 
+    #[test]
+    fn only_yields_shutdown_once() {
+        let shutdown1 = ShutdownChannel::new();
+        let mut shutdown2 = shutdown1.clone();
+
+        // a normal task that recv's from a shutdown handle should see the event
+        let mut recv_task2_1 = tokio_test::task::spawn(shutdown2.recv());
+        assert_pending!(recv_task2_1.poll());
+
+        shutdown1.send();
+
+        assert!(recv_task2_1.is_woken());
+        assert_ready!(recv_task2_1.poll());
+        drop(recv_task2_1);
+
+        // trying to recv from the same handle more than once will always return
+        // pending
+        let mut recv_task2_2 = tokio_test::task::spawn(shutdown2.recv());
+        assert_pending!(recv_task2_2.poll());
+        assert_pending!(recv_task2_2.poll());
+
+        shutdown1.send();
+
+        // still pending!
+        assert_pending!(recv_task2_2.poll());
+        assert_pending!(recv_task2_2.poll());
+        drop(recv_task2_2);
+
+        // but a new handle will get a new chance to see the shutdown event
+        let mut shutdown3 = shutdown2.clone();
+        let mut recv_task3 = tokio_test::task::spawn(shutdown3.recv());
+        assert_ready!(recv_task3.poll());
+    }
+
     #[tokio::test(start_paused = true)]
     async fn subscribe_after_close_is_ok() {
         // Basic test: subscribe, wait, shutdown
         let shutdown1 = ShutdownChannel::new();
-        let shutdown2 = shutdown1.clone();
+        let mut shutdown2 = shutdown1.clone();
         time::sleep(Duration::from_secs(1)).await;
         shutdown1.send();
         time::timeout(Duration::from_nanos(1), shutdown2.recv())
@@ -86,7 +150,7 @@ mod test {
             .expect("Did not finish immediately");
 
         // 'Subscribing' after close should immediately finish
-        let shutdown3 = shutdown2.clone();
+        let mut shutdown3 = shutdown2.clone();
         assert!(shutdown3.try_recv());
         time::timeout(Duration::from_nanos(1), shutdown3.recv())
             .await

--- a/lexe-ln/src/bitcoind/mod.rs
+++ b/lexe-ln/src/bitcoind/mod.rs
@@ -99,7 +99,7 @@ impl LexeBitcoind {
         let background_fees = self.background_fees.clone();
         let normal_fees = self.normal_fees.clone();
         let high_prio_fees = self.high_prio_fees.clone();
-        let shutdown = self.shutdown.clone();
+        let mut shutdown = self.shutdown.clone();
 
         // TODO(max): Instrument with shutdown
         LxTask::spawn(async move {

--- a/node/src/inactivity_timer.rs
+++ b/node/src/inactivity_timer.rs
@@ -91,7 +91,7 @@ impl InactivityTimer {
                         },
                     }
                 }
-                _ = self.shutdown.recv() => {
+                () = self.shutdown.recv() => {
                     info!("Inactivity timer received shutdown signal");
                     break;
                 }

--- a/node/src/lexe/background_processor.rs
+++ b/node/src/lexe/background_processor.rs
@@ -38,7 +38,7 @@ impl LexeBackgroundProcessor {
         event_handler: Arc<InvoicePayerType>,
         gossip_sync: Arc<P2PGossipSyncType>,
         scorer: Arc<Mutex<ProbabilisticScorerType>>,
-        shutdown: ShutdownChannel,
+        mut shutdown: ShutdownChannel,
     ) -> LxTask<()> {
         LxTask::spawn(async move {
             let mut process_timer = interval(PROCESS_EVENTS_INTERVAL);
@@ -110,7 +110,7 @@ impl LexeBackgroundProcessor {
                     }
 
                     // --- Shutdown branch --- //
-                    _ = shutdown.recv() => {
+                    () = shutdown.recv() => {
                         info!("Background processor shutting down");
                         break;
                     }

--- a/node/src/lexe/sync.rs
+++ b/node/src/lexe/sync.rs
@@ -195,7 +195,7 @@ impl SyncedChainListeners {
     pub fn feed_chain_monitor_and_spawn_spv(
         mut self,
         chain_monitor: Arc<ChainMonitorType>,
-        shutdown: ShutdownChannel,
+        mut shutdown: ShutdownChannel,
     ) -> anyhow::Result<LxTask<()>> {
         for cmcl in self.cmcls {
             let (channel_monitor, funding_outpoint) =

--- a/node/src/provision.rs
+++ b/node/src/provision.rs
@@ -172,7 +172,7 @@ pub async fn provision<R: Crng>(
 
     // we'll trigger `shutdown` when we've completed the provisioning process
     let shutdown = ShutdownChannel::new();
-    let shutdown_clone = shutdown.clone();
+    let mut shutdown_clone = shutdown.clone();
     let shutdown_fut = async move {
         // don't wait forever for the client
         match tokio::time::timeout(PROVISION_TIMEOUT, shutdown_clone.recv())


### PR DESCRIPTION
* Previously, `shutdown.recv()` would immediately yield if a shutdown had already been observed. This caused a problem where a particularly complex event loop ended up short-circuiting into the shutdown branch in a tight loop.

* This PR changes the semantics of `shutdown.recv()` so that it will only ever observe a shutdown at-most-once. If you call it again after previously observing a shutdown, the future will never yield.

* Each `clone` of a `shutdown` tracks this independently; in other words, each handle gets its own chance to observe a shutdown message, regardless of whether the shutdown has been triggered long ago. However, once it has seen the shutdown, it will never observe it again.