### PR TITLE
Implement & use overflow-safe exponential backoff

### DIFF
--- a/common/src/backoff.rs
+++ b/common/src/backoff.rs
@@ -1,0 +1,45 @@
+use std::cmp::min;
+use std::time::Duration;
+
+use crate::const_assert;
+
+const INITIAL_WAIT_MS: u64 = 250;
+const MAXIMUM_WAIT_MS: u64 = 32_000;
+const EXP_BASE: u64 = 2;
+
+const_assert!(INITIAL_WAIT_MS != 0);
+
+/// Get a iterator of [`Duration`]s which can be passed into e.g.
+/// [`tokio::time::sleep`] to observe time-based exponential backoff.
+///
+/// ```
+/// # use common::backoff;
+/// # #[tokio::test(start_paused = true)]
+/// # async fn backoff_example() {
+/// let mut backoff_durations = backoff::get_backoff_iter();
+/// for _ in 0..10 {
+///     tokio::time::sleep(backoff_durations.next().unwrap()).await;
+/// }
+/// # }
+/// ```
+pub fn get_backoff_iter() -> impl Iterator<Item = Duration> {
+    (0u32..).map(|index| {
+        let factor = EXP_BASE.saturating_pow(index);
+        let wait_ms = INITIAL_WAIT_MS.saturating_mul(factor);
+        let bounded_wait_ms = min(wait_ms, MAXIMUM_WAIT_MS);
+        Duration::from_millis(bounded_wait_ms)
+    })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn no_integer_overflow() {
+        let mut backoff_durations = get_backoff_iter();
+        for _ in 0..200 {
+            backoff_durations.next();
+        }
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,6 +19,8 @@ pub use secrecy::Secret;
 pub mod api;
 /// Remote attestation.
 pub mod attest;
+/// Exponential backoff.
+pub mod backoff;
 /// User node CLI.
 pub mod cli;
 /// Mobile client to the node.
@@ -48,6 +50,19 @@ pub mod task;
 
 #[cfg(test)]
 pub mod test_utils;
+
+/// Assert at compile that that a boolean expression evaluates to true.
+/// Implementation copied from the static_assertions crate.
+#[macro_export]
+macro_rules! const_assert {
+    ($x:expr $(,)?) => {
+        #[allow(unknown_lints, clippy::eq_op)]
+        const _: [(); 0 - !{
+            const CONST_ASSERT: bool = $x;
+            CONST_ASSERT
+        } as usize] = [];
+    };
+}
 
 /// Assert at compile time that two `usize` values are equal. This assert has a
 /// nice benefit where there compiler error will actually _print out_ the


### PR DESCRIPTION
- Used [`saturating_pow`](https://doc.rust-lang.org/std/primitive.u64.html#method.saturating_pow) and [`saturating_mul`](https://doc.rust-lang.org/std/primitive.u64.html#method.saturating_mul) to fix a bug where the exponential backoff would overflow at the ~57th call to `next()`.
- Used the overflow safe implementation across all crates.
- Added a `const_assert` macro for compile-time assertions.