### PR TITLE
chore: update `rust-sgx`, `mio`, and `tokio`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 [[package]]
 name = "aesm-client"
 version = "0.5.4"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "byteorder",
  "failure",
@@ -155,9 +155,9 @@ dependencies = [
 [[package]]
 name = "async-usercalls"
 version = "0.1.0"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
- "crossbeam-channel 0.5.6",
+ "crossbeam-channel",
  "fnv",
  "fortanix-sgx-abi",
  "ipc-queue",
@@ -553,21 +553,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-channel 0.5.6",
+ "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
  "crossbeam-queue",
- "crossbeam-utils 0.8.11",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -577,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -588,7 +578,7 @@ checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -599,7 +589,7 @@ checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
+ "crossbeam-utils",
  "memoffset",
  "once_cell",
  "scopeguard",
@@ -612,18 +602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.11",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg",
- "cfg-if 0.1.10",
- "lazy_static",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -664,7 +643,7 @@ dependencies = [
 [[package]]
 name = "dcap-ql"
 version = "0.3.4"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "byteorder",
  "failure",
@@ -725,7 +704,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "enclave-runner"
 version = "0.5.1"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "crossbeam",
  "failure",
@@ -840,8 +819,8 @@ dependencies = [
 
 [[package]]
 name = "fortanix-sgx-abi"
-version = "0.4.1"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+version = "0.5.0"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 
 [[package]]
 name = "futures"
@@ -1149,7 +1128,7 @@ dependencies = [
 [[package]]
 name = "ipc-queue"
 version = "0.2.0"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "fortanix-sgx-abi",
 ]
@@ -1300,12 +1279,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,25 +1336,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.6"
-source = "git+https://github.com/lexe-tech/mio?branch=mio-sgx-0.7.6#61d12d86838ded9f9b47780ae6420bcc22090a93"
+version = "0.8.4"
+source = "git+https://github.com/lexe-tech/mio?branch=mio-sgx-0.8.4#9cfe682ba11465d6a2d4140afefacb4b6c644716"
 dependencies = [
  "async-usercalls",
- "crossbeam-channel 0.4.4",
+ "crossbeam-channel",
  "libc",
  "log",
- "miow",
- "ntapi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1457,15 +1420,6 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
-]
-
-[[package]]
-name = "ntapi"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
-dependencies = [
- "winapi",
 ]
 
 [[package]]
@@ -2166,7 +2120,7 @@ dependencies = [
 [[package]]
 name = "sgx-isa"
 version = "0.4.0"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "bitflags",
 ]
@@ -2183,7 +2137,7 @@ dependencies = [
 [[package]]
 name = "sgxs"
 version = "0.7.3"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "byteorder",
  "failure",
@@ -2198,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "sgxs-loaders"
 version = "0.3.3"
-source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#70d11205fed08e49886bb25a1ea3df19928e8287"
+source = "git+https://github.com/lexe-tech/rust-sgx?branch=lexe#4aa8f13487c772dd4d24b7cc54bd2d5432803f7a"
 dependencies = [
  "bitflags",
  "failure",
@@ -2512,22 +2466,24 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.15.0"
-source = "git+https://github.com/lexe-tech/tokio?branch=tokio-sgx-1.15.0#1123412aaeb904ff030ec469e9471f11392d35d2"
+version = "1.21.2"
+source = "git+https://github.com/lexe-tech/tokio?branch=tokio-sgx-1.21.2#1d290cf1087e2671b3b689b0968537861d142759"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
  "mio",
  "pin-project-lite",
+ "socket2",
  "tokio-macros",
  "winapi",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
-source = "git+https://github.com/lexe-tech/tokio?branch=tokio-sgx-1.15.0#1123412aaeb904ff030ec469e9471f11392d35d2"
+version = "1.8.0"
+source = "git+https://github.com/lexe-tech/tokio?branch=tokio-sgx-1.21.2#1d290cf1087e2671b3b689b0968537861d142759"
 dependencies = [
  "proc-macro2 1.0.43",
  "quote 1.0.21",
@@ -2981,6 +2937,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ async-usercalls = { git = "https://github.com/lexe-tech/rust-sgx", branch = "lex
 dcap-ql = { git = "https://github.com/lexe-tech/rust-sgx", branch = "lexe" }
 enclave-runner = { git = "https://github.com/lexe-tech/rust-sgx", branch = "lexe" }
 hyper = { git = "https://github.com/lexe-tech/hyper", branch = "hyper-sgx-0.14.18" }
-mio = { git = "https://github.com/lexe-tech/mio", branch = "mio-sgx-0.7.6" }
+mio = { git = "https://github.com/lexe-tech/mio", branch = "mio-sgx-0.8.4" }
 ring = { git = "https://github.com/lexe-tech/ring", branch = "support-sgx-0.16.20" }
 sgx-isa = { git = "https://github.com/lexe-tech/rust-sgx", branch = "lexe" }
 sgxs-loaders = { git = "https://github.com/lexe-tech/rust-sgx", branch = "lexe" }
-tokio = { git = "https://github.com/lexe-tech/tokio",  branch = "tokio-sgx-1.15.0" }
+tokio = { git = "https://github.com/lexe-tech/tokio",  branch = "tokio-sgx-1.21.2" }
 
 [profile.dev]
 # This fixes 'warning: can't find symbol' when debugging, but breaks the

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -108,12 +108,12 @@ yasna = { version = "0.5", default-features = false, features = ["num-bigint"] }
 #   declared in `common`'s Cargo.toml and propagated to other crates by
 #   workspace-level dependency resolution.
 
-hyper = "=0.14.18"
-mio = "=0.7.6"
+hyper = { version = "=0.14.18", default-features = false }
+mio = "=0.8.4"
 # Safe and small crypto primitives based on BoringSSL
 ring = "=0.16.20"
 
-tokio = { version = "=1.15.0", default-features = false, features = [
+tokio = { version = "=1.21.2", default-features = false, features = [
     "io-util",
     "macros",
     "rt",

--- a/lexe-ln/Cargo.toml
+++ b/lexe-ln/Cargo.toml
@@ -73,7 +73,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 #   declared in `common`'s Cargo.toml and propagated to other crates by
 #   workspace-level dependency resolution.
 
-tokio = { version = "=1.15.0", default-features = false, features = [
+tokio = { version = "=1.21.2", default-features = false, features = [
     "io-util",
     "macros",
     "net",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -94,7 +94,7 @@ warp = { git = "https://github.com/lexe-tech/warp", branch = "lexe", default-fea
 #   declared in `common`'s Cargo.toml and propagated to other crates by
 #   workspace-level dependency resolution.
 
-tokio = { version = "=1.15.0", default-features = false, features = [
+tokio = { version = "=1.21.2", default-features = false, features = [
     "io-util",
     "macros",
     "net",
@@ -115,7 +115,7 @@ proptest = { version = "1", default-features = false, features = ["alloc"] }
 # Arbitrary derive macro
 proptest-derive = "0.3"
 # Tokio features used when testing
-tokio = { version = "=1.15.0", default-features = false, features = [
+tokio = { version = "=1.21.2", default-features = false, features = [
     "io-util",
     "macros",
     "rt",

--- a/run-sgx/Cargo.toml
+++ b/run-sgx/Cargo.toml
@@ -27,7 +27,7 @@ rustc-demangle = "0.1"
 serde = { version = "1", features = ["derive"] }
 toml = "0.5"
 # Must match version in workspace exactly.
-tokio = { version = "=1.15.0", default-features = false, features = [
+tokio = { version = "=1.21.2", default-features = false, features = [
     "net"
 ] }
 


### PR DESCRIPTION
* rust-sgx update to latest master + async patch: https://github.com/lexe-tech/rust-sgx/commits/lexe
* mio 0.7.6 -> 0.8.4: https://github.com/lexe-tech/mio/commits/mio-sgx-0.8.4
* tokio 1.15.0 -> 1.21.2: https://github.com/lexe-tech/tokio/commits/tokio-sgx-1.21.2