### PR TITLE
error: less error prone `error_kind!` macro

### DIFF
--- a/common/src/enclave/mod.rs
+++ b/common/src/enclave/mod.rs
@@ -37,7 +37,6 @@ pub const MIN_SGX_CPUSVN: MinCpusvn =
     MinCpusvn::new(hex::decode_const(b"08080e0dffff01000000000000000000"));
 
 #[derive(Debug, Error)]
-#[error("error")]
 pub enum Error {
     #[error("SGX error: {0:?}")]
     SgxError(sgx_isa::ErrorCode),

--- a/node/src/provision.rs
+++ b/node/src/provision.rs
@@ -174,9 +174,9 @@ async fn provision_handler(
         measurement: ctx.measurement,
     };
     let sealed_seed = SealedSeed::seal_from_root_seed(&mut ctx.rng, &root_seed)
-        .map_err(|_| NodeApiError {
+        .map_err(|err| NodeApiError {
             kind: NodeErrorKind::Provision,
-            msg: String::from("Could not seal secret"),
+            msg: format!("{err:#}"),
         })?;
 
     let batch = NodeInstanceSeed {
@@ -194,12 +194,9 @@ async fn provision_handler(
     let token = authenticator
         .authenticate(&*ctx.api, SystemTime::now())
         .await
-        .map_err(|err| {
-            let kind = NodeErrorKind::BadAuth;
-            NodeApiError {
-                kind,
-                msg: format!("{kind}: {err:#}"),
-            }
+        .map_err(|err| NodeApiError {
+            kind: NodeErrorKind::BadAuth,
+            msg: format!("{err:#}"),
         })?
         .token;
 


### PR DESCRIPTION
* serializable error kinds written with small `error_kind!` macro, which removes error-prone kind <-> code/name/msg mapping fns.

* all error kinds now use an `Unknown(_)` variant rather than just a fixed `Unknown = 0` variant so (1) we can preserve the underlying error code for better debugging and (2) intermediate proxies can avoid losing information.

* rename `CommonError` -> `RestClientError` to reflect usage.

* more accurately reflect reqwest error variants in `RestClientErrorKind`.

* now require that all error kind are a strict superset of the `RestClientErrorKind`s. This lets us stop retrying on rest client error kinds correctly, when requested.

* new approach lets us easily assert all error kind invariants in a test.