### PR TITLE
fix: wait for provisioning before loading receive data

### DIFF
--- a/app/lib/route/receive/page.dart
+++ b/app/lib/route/receive/page.dart
@@ -40,6 +40,7 @@ import 'package:lexeapp/route/receive/state.dart'
         LnOfferInputs,
         PaymentOffer,
         PaymentOfferKind;
+import 'package:lexeapp/service/provision.dart' show ProvisionService;
 import 'package:lexeapp/settings.dart' show LxSettings;
 import 'package:lexeapp/share.dart' show LxShare;
 import 'package:lexeapp/string_ext.dart';
@@ -64,6 +65,59 @@ const int lnInvoicePageIdx = 0;
 const int lnOfferPageIdx = 1;
 const int btcPageIdx = 2;
 
+class ReceiveProvisionGate {
+  Future<bool>? waitForProvisionFuture;
+
+  Future<bool> ensureProvisioned(ProvisionService? provisionService) async {
+    if (provisionService == null || provisionService.isProvisioned.value) {
+      return true;
+    }
+
+    final existing = this.waitForProvisionFuture;
+    if (existing != null) {
+      return existing;
+    }
+
+    final future = this._waitForProvision(provisionService);
+    this.waitForProvisionFuture = future;
+
+    try {
+      return await future;
+    } finally {
+      if (identical(this.waitForProvisionFuture, future)) {
+        this.waitForProvisionFuture = null;
+      }
+    }
+  }
+
+  Future<bool> _waitForProvision(ProvisionService provisionService) async {
+    final completer = Completer<bool>();
+
+    void maybeComplete() {
+      if (completer.isCompleted) return;
+
+      if (provisionService.isProvisioned.value) {
+        completer.complete(true);
+      } else if (!provisionService.isProvisioning.value) {
+        completer.complete(false);
+      }
+    }
+
+    provisionService.isProvisioned.addListener(maybeComplete);
+    provisionService.isProvisioning.addListener(maybeComplete);
+
+    unawaited(provisionService.provision());
+    maybeComplete();
+
+    final isProvisioned = await completer.future;
+
+    provisionService.isProvisioned.removeListener(maybeComplete);
+    provisionService.isProvisioning.removeListener(maybeComplete);
+
+    return isProvisioned;
+  }
+}
+
 class ReceivePaymentPage extends StatelessWidget {
   const ReceivePaymentPage({
     super.key,
@@ -72,6 +126,7 @@ class ReceivePaymentPage extends StatelessWidget {
     required this.featureFlags,
     required this.fiatRate,
     required this.settings,
+    this.provisionService,
     this.designInitialPageIdx,
     this.designInitialLightningType,
   });
@@ -85,6 +140,9 @@ class ReceivePaymentPage extends StatelessWidget {
 
   /// User settings.
   final LxSettings settings;
+
+  /// Node provisioning state from the wallet page.
+  final ProvisionService? provisionService;
 
   /// (Design mode screenshot automation only) Initial page to show.
   final int? designInitialPageIdx;
@@ -100,6 +158,7 @@ class ReceivePaymentPage extends StatelessWidget {
     fiatRate: this.fiatRate,
     settings: this.settings,
     viewportWidth: MediaQuery.sizeOf(context).width,
+    provisionService: this.provisionService,
     designInitialPageIdx: this.designInitialPageIdx,
     designInitialLightningType: this.designInitialLightningType,
   );
@@ -116,6 +175,7 @@ class ReceivePaymentPageInner extends StatefulWidget {
     required this.fiatRate,
     required this.settings,
     required this.viewportWidth,
+    this.provisionService,
     this.designInitialPageIdx,
     this.designInitialLightningType,
   });
@@ -126,6 +186,7 @@ class ReceivePaymentPageInner extends StatefulWidget {
   final ValueListenable<FiatRate?> fiatRate;
   final LxSettings settings;
   final double viewportWidth;
+  final ProvisionService? provisionService;
 
   final int? designInitialPageIdx;
   final PaymentOfferKind? designInitialLightningType;
@@ -136,6 +197,8 @@ class ReceivePaymentPageInner extends StatefulWidget {
 }
 
 class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
+  final ReceiveProvisionGate provisionGate = ReceiveProvisionGate();
+
   /// Controls the [PageView].
   late PageController pageController = this.newPageController();
 
@@ -389,6 +452,13 @@ class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
 
     info("ReceivePaymentPage: fetchBtc: inputs: $inputs");
 
+    if (!await this.provisionGate.ensureProvisioned(
+          this.widget.provisionService,
+        ) ||
+        !this.mounted) {
+      return null;
+    }
+
     final result = await Result.tryFfiAsync(this.widget.app.getAddress);
 
     final String address;
@@ -484,6 +554,13 @@ class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
 
     info("ReceivePaymentPage: fetchLnInvoice: inputs: $inputs");
 
+    if (!await this.provisionGate.ensureProvisioned(
+          this.widget.provisionService,
+        ) ||
+        !this.mounted) {
+      return null;
+    }
+
     final result = await Result.tryFfiAsync(
       () => this.widget.app.createInvoice(req: req),
     );
@@ -546,6 +623,13 @@ class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
     );
 
     info("ReceivePaymentPage: fetchLnOffer: inputs: $inputs");
+
+    if (!await this.provisionGate.ensureProvisioned(
+          this.widget.provisionService,
+        ) ||
+        !this.mounted) {
+      return null;
+    }
 
     final result = await Result.tryFfiAsync(
       () => this.widget.app.createOffer(req: req),

--- a/app/lib/route/wallet.dart
+++ b/app/lib/route/wallet.dart
@@ -398,6 +398,7 @@ class WalletPageState extends State<WalletPage> {
           featureFlags: this.widget.featureFlags,
           fiatRate: this.fiatRateService.fiatRate,
           settings: this.widget.settings,
+          provisionService: this.provisionService,
         ),
       ),
     );

--- a/app/lib/service/provision.dart
+++ b/app/lib/service/provision.dart
@@ -34,7 +34,6 @@ class ProvisionService {
     this._isProvisioning.value = true;
     final res = await Result.tryFfiAsync(() => this._app.provision());
     if (this.isDisposed) return;
-    this._isProvisioning.value = false;
 
     switch (res) {
       case Ok():
@@ -47,6 +46,8 @@ class ProvisionService {
         error("provision: err: ${err.message}");
         break;
     }
+
+    this._isProvisioning.value = false;
   }
 
   void wrapListener(void Function() listener) {

--- a/app/test/receive_page_test.dart
+++ b/app/test/receive_page_test.dart
@@ -1,0 +1,104 @@
+import 'package:app_rs_dart/ffi/api.dart'
+    show
+        CreateInvoiceRequest,
+        CreateInvoiceResponse,
+        CreateOfferRequest,
+        CreateOfferResponse;
+import 'package:app_rs_dart/ffi/types.dart' show Invoice, Offer;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lexeapp/design_mode/mocks.dart' as mocks;
+import 'package:lexeapp/result.dart' show FfiError;
+import 'package:lexeapp/route/receive/page.dart' show ReceiveProvisionGate;
+import 'package:lexeapp/service/provision.dart' show ProvisionService;
+
+class _ProvisioningMockAppHandle extends mocks.MockAppHandle {
+  _ProvisioningMockAppHandle()
+    : super(
+        balance: mocks.balanceDefault,
+        payments: const [],
+        channels: const [],
+      );
+
+  static const address = "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl";
+
+  bool isProvisioned = false;
+  int preProvisionFailures = 0;
+
+  @override
+  Future<void> provision() async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    this.isProvisioned = true;
+  }
+
+  @override
+  Future<String> getAddress() async {
+    if (!this.isProvisioned) {
+      this.preProvisionFailures += 1;
+      throw const FfiError("App is not provisioned").toFfi();
+    }
+
+    return address;
+  }
+
+  @override
+  Future<CreateInvoiceResponse> createInvoice({
+    required CreateInvoiceRequest req,
+  }) async {
+    if (!this.isProvisioned) {
+      this.preProvisionFailures += 1;
+      throw const FfiError("App is not provisioned").toFfi();
+    }
+
+    final now = DateTime.now();
+    return CreateInvoiceResponse(
+      invoice: Invoice(
+        string: mocks.dummyInvoiceInboundPending01.invoice!.string,
+        createdAt: now.millisecondsSinceEpoch,
+        expiresAt: now
+            .add(Duration(seconds: req.expirySecs))
+            .millisecondsSinceEpoch,
+        amountSats: req.amountSats,
+        description: req.description,
+        payeePubkey: mocks.dummyInvoiceInboundPending01.invoice!.payeePubkey,
+      ),
+    );
+  }
+
+  @override
+  Future<CreateOfferResponse> createOffer({
+    required CreateOfferRequest req,
+  }) async {
+    if (!this.isProvisioned) {
+      this.preProvisionFailures += 1;
+      throw const FfiError("App is not provisioned").toFfi();
+    }
+
+    return CreateOfferResponse(
+      offer: Offer(
+        string: mocks.dummyOfferInboundPayment01.offer!.string,
+        expiresAt: null,
+        amountSats: req.amountSats,
+        description: req.description,
+      ),
+    );
+  }
+}
+
+void main() {
+  test(
+    "provision gate waits for provisioning before allowing fetches",
+    () async {
+      final app = _ProvisioningMockAppHandle();
+      final provisionService = ProvisionService(app: app);
+      final provisionGate = ReceiveProvisionGate();
+
+      final isProvisioned = await provisionGate.ensureProvisioned(
+        provisionService,
+      );
+
+      expect(isProvisioned, isTrue);
+      expect(app.preProvisionFailures, 0);
+      expect(app.isProvisioned, isTrue);
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- wait for receive data fetches to block on wallet provisioning instead of hitting FFI too early
- pass the wallet page provisioning state into the receive page so the startup race is handled in one place
- add focused regression coverage for the provisioning gate and keep provisioning signals ordered consistently on success

## Review Notes
- production review found a follow-on issue in `ProvisionService`: a successful provision briefly exposed `isProvisioned=false` after `isProvisioning=false`; that ordering is now fixed
- only the Flutter app receive/provisioning path is included in this change; unrelated local Rust changes in the worktree were not staged

## Test Plan
- `/Users/vincenzopalazzo/development/flutter-3.32.8/bin/flutter test test/receive_page_test.dart`
- `/Users/vincenzopalazzo/development/flutter-3.32.8/bin/flutter test test/payment_detail_test.dart`
- `/Users/vincenzopalazzo/development/flutter-3.32.8/bin/flutter analyze app/lib/route/receive/page.dart app/lib/service/provision.dart app/lib/route/wallet.dart app/test/receive_page_test.dart`
