### PR TITLE
fix(send): allow paying above BOLT12 offer minimums

### DIFF
--- a/app-rs/src/ffi/types.rs
+++ b/app-rs/src/ffi/types.rs
@@ -650,6 +650,8 @@ pub struct Offer {
     pub description: Option<String>,
 
     pub expires_at: Option<i64>,
+    /// The amount embedded in the BOLT12 offer itself, if any.
+    pub embedded_amount_sats: Option<u64>,
     /// The amount that we'll prompt the user to pay.
     ///
     /// When paying an offer from a BIP321 URI, this uses the offer's embedded
@@ -668,6 +670,7 @@ impl From<&OfferRs> for Offer {
             description: offer.description().map(String::from),
 
             expires_at: offer.expires_at().map(TimestampMs::to_i64),
+            embedded_amount_sats: offer.amount().map(|amt| amt.sats_u64()),
             amount_sats: offer.amount().map(|amt| amt.sats_u64()),
 
             payee: offer.payee().map(String::from),

--- a/app-rs/src/frb_generated.rs
+++ b/app-rs/src/frb_generated.rs
@@ -2103,6 +2103,8 @@ impl SseDecode for crate::ffi::types::Offer {
         let mut var_string = <String>::sse_decode(deserializer);
         let mut var_description = <Option<String>>::sse_decode(deserializer);
         let mut var_expiresAt = <Option<i64>>::sse_decode(deserializer);
+        let mut var_embeddedAmountSats =
+            <Option<u64>>::sse_decode(deserializer);
         let mut var_amountSats = <Option<u64>>::sse_decode(deserializer);
         let mut var_payee = <Option<String>>::sse_decode(deserializer);
         let mut var_payeePubkey = <Option<String>>::sse_decode(deserializer);
@@ -2110,6 +2112,7 @@ impl SseDecode for crate::ffi::types::Offer {
             string: var_string,
             description: var_description,
             expires_at: var_expiresAt,
+            embedded_amount_sats: var_embeddedAmountSats,
             amount_sats: var_amountSats,
             payee: var_payee,
             payee_pubkey: var_payeePubkey,
@@ -3948,6 +3951,7 @@ impl flutter_rust_bridge::IntoDart for crate::ffi::types::Offer {
             self.string.into_into_dart().into_dart(),
             self.description.into_into_dart().into_dart(),
             self.expires_at.into_into_dart().into_dart(),
+            self.embedded_amount_sats.into_into_dart().into_dart(),
             self.amount_sats.into_into_dart().into_dart(),
             self.payee.into_into_dart().into_dart(),
             self.payee_pubkey.into_into_dart().into_dart(),
@@ -5522,6 +5526,7 @@ impl SseEncode for crate::ffi::types::Offer {
         <String>::sse_encode(self.string, serializer);
         <Option<String>>::sse_encode(self.description, serializer);
         <Option<i64>>::sse_encode(self.expires_at, serializer);
+        <Option<u64>>::sse_encode(self.embedded_amount_sats, serializer);
         <Option<u64>>::sse_encode(self.amount_sats, serializer);
         <Option<String>>::sse_encode(self.payee, serializer);
         <Option<String>>::sse_encode(self.payee_pubkey, serializer);

--- a/app/lib/route/receive/page.dart
+++ b/app/lib/route/receive/page.dart
@@ -40,6 +40,7 @@ import 'package:lexeapp/route/receive/state.dart'
         LnOfferInputs,
         PaymentOffer,
         PaymentOfferKind;
+import 'package:lexeapp/service/provision.dart' show ProvisionService;
 import 'package:lexeapp/settings.dart' show LxSettings;
 import 'package:lexeapp/share.dart' show LxShare;
 import 'package:lexeapp/string_ext.dart';
@@ -64,6 +65,59 @@ const int lnInvoicePageIdx = 0;
 const int lnOfferPageIdx = 1;
 const int btcPageIdx = 2;
 
+class ReceiveProvisionGate {
+  Future<bool>? waitForProvisionFuture;
+
+  Future<bool> ensureProvisioned(ProvisionService? provisionService) async {
+    if (provisionService == null || provisionService.isProvisioned.value) {
+      return true;
+    }
+
+    final existing = this.waitForProvisionFuture;
+    if (existing != null) {
+      return existing;
+    }
+
+    final future = this._waitForProvision(provisionService);
+    this.waitForProvisionFuture = future;
+
+    try {
+      return await future;
+    } finally {
+      if (identical(this.waitForProvisionFuture, future)) {
+        this.waitForProvisionFuture = null;
+      }
+    }
+  }
+
+  Future<bool> _waitForProvision(ProvisionService provisionService) async {
+    final completer = Completer<bool>();
+
+    void maybeComplete() {
+      if (completer.isCompleted) return;
+
+      if (provisionService.isProvisioned.value) {
+        completer.complete(true);
+      } else if (!provisionService.isProvisioning.value) {
+        completer.complete(false);
+      }
+    }
+
+    provisionService.isProvisioned.addListener(maybeComplete);
+    provisionService.isProvisioning.addListener(maybeComplete);
+
+    unawaited(provisionService.provision());
+    maybeComplete();
+
+    final isProvisioned = await completer.future;
+
+    provisionService.isProvisioned.removeListener(maybeComplete);
+    provisionService.isProvisioning.removeListener(maybeComplete);
+
+    return isProvisioned;
+  }
+}
+
 class ReceivePaymentPage extends StatelessWidget {
   const ReceivePaymentPage({
     super.key,
@@ -72,6 +126,7 @@ class ReceivePaymentPage extends StatelessWidget {
     required this.featureFlags,
     required this.fiatRate,
     required this.settings,
+    this.provisionService,
     this.designInitialPageIdx,
     this.designInitialLightningType,
   });
@@ -85,6 +140,9 @@ class ReceivePaymentPage extends StatelessWidget {
 
   /// User settings.
   final LxSettings settings;
+
+  /// Node provisioning state from the wallet page.
+  final ProvisionService? provisionService;
 
   /// (Design mode screenshot automation only) Initial page to show.
   final int? designInitialPageIdx;
@@ -100,6 +158,7 @@ class ReceivePaymentPage extends StatelessWidget {
     fiatRate: this.fiatRate,
     settings: this.settings,
     viewportWidth: MediaQuery.sizeOf(context).width,
+    provisionService: this.provisionService,
     designInitialPageIdx: this.designInitialPageIdx,
     designInitialLightningType: this.designInitialLightningType,
   );
@@ -116,6 +175,7 @@ class ReceivePaymentPageInner extends StatefulWidget {
     required this.fiatRate,
     required this.settings,
     required this.viewportWidth,
+    this.provisionService,
     this.designInitialPageIdx,
     this.designInitialLightningType,
   });
@@ -126,6 +186,7 @@ class ReceivePaymentPageInner extends StatefulWidget {
   final ValueListenable<FiatRate?> fiatRate;
   final LxSettings settings;
   final double viewportWidth;
+  final ProvisionService? provisionService;
 
   final int? designInitialPageIdx;
   final PaymentOfferKind? designInitialLightningType;
@@ -136,6 +197,8 @@ class ReceivePaymentPageInner extends StatefulWidget {
 }
 
 class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
+  final ReceiveProvisionGate provisionGate = ReceiveProvisionGate();
+
   /// Controls the [PageView].
   late PageController pageController = this.newPageController();
 
@@ -389,6 +452,13 @@ class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
 
     info("ReceivePaymentPage: fetchBtc: inputs: $inputs");
 
+    if (!await this.provisionGate.ensureProvisioned(
+          this.widget.provisionService,
+        ) ||
+        !this.mounted) {
+      return null;
+    }
+
     final result = await Result.tryFfiAsync(this.widget.app.getAddress);
 
     final String address;
@@ -484,6 +554,13 @@ class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
 
     info("ReceivePaymentPage: fetchLnInvoice: inputs: $inputs");
 
+    if (!await this.provisionGate.ensureProvisioned(
+          this.widget.provisionService,
+        ) ||
+        !this.mounted) {
+      return null;
+    }
+
     final result = await Result.tryFfiAsync(
       () => this.widget.app.createInvoice(req: req),
     );
@@ -546,6 +623,13 @@ class ReceivePaymentPageInnerState extends State<ReceivePaymentPageInner> {
     );
 
     info("ReceivePaymentPage: fetchLnOffer: inputs: $inputs");
+
+    if (!await this.provisionGate.ensureProvisioned(
+          this.widget.provisionService,
+        ) ||
+        !this.mounted) {
+      return null;
+    }
 
     final result = await Result.tryFfiAsync(
       () => this.widget.app.createOffer(req: req),

--- a/app/lib/route/send/page.dart
+++ b/app/lib/route/send/page.dart
@@ -439,6 +439,19 @@ class _SendPaymentAmountPageState extends State<SendPaymentAmountPage> {
   }
 
   Result<(), String> validateAmount(int amount) {
+    if (this.widget.sendCtx.paymentMethod case PaymentMethod_Offer(
+      :final field0,
+    )) {
+      final minimumAmountSats = field0.embeddedAmountSats;
+      if (minimumAmountSats != null && amount < minimumAmountSats) {
+        final minimumAmountStr = currency_format.formatSatsAmount(
+          minimumAmountSats,
+          bitcoinSymbol: true,
+        );
+        return Err("Can't send less than $minimumAmountStr");
+      }
+    }
+
     final kind = this.widget.sendCtx.paymentMethod.kind();
     final balance = this.widget.sendCtx.balance;
     final balanceMaxSendableSats = balance.maxSendableByKind(kind);
@@ -525,6 +538,7 @@ class _SendPaymentAmountPageState extends State<SendPaymentAmountPage> {
             validate: this.validateAmount,
             allowEmpty: false,
             allowZero: false,
+            initialValue: paymentMethod.amountSats(),
           ),
 
           // Description (if available)

--- a/app/lib/route/send/state.dart
+++ b/app/lib/route/send/state.dart
@@ -42,6 +42,14 @@ import 'package:lexeapp/prelude.dart';
 import 'package:lexeapp/service/send_payment_service.dart'
     show SendPaymentService;
 
+int? requestedOfferAmountSats(Offer offer, int amountSats) {
+  final minimumAmountSats = offer.embeddedAmountSats;
+  if (minimumAmountSats == null || amountSats != minimumAmountSats) {
+    return amountSats;
+  }
+  return null;
+}
+
 /// The outcome of a successful send flow.
 @immutable
 final class SendFlowResult {
@@ -167,7 +175,8 @@ class SendState_NeedAmount implements SendState {
   int? canPreflightImmediately() => switch (this.paymentMethod) {
     PaymentMethod_Onchain(:final field0) => field0.amountSats,
     PaymentMethod_Invoice(:final field0) => field0.amountSats,
-    PaymentMethod_Offer(:final field0) => field0.amountSats,
+    PaymentMethod_Offer(:final field0) =>
+      field0.embeddedAmountSats == null ? field0.amountSats : null,
     PaymentMethod_LnurlPayRequest(:final field0) =>
       field0.minSendableMsat == field0.maxSendableMsat
           ? field0.minSendableMsat ~/ 1000
@@ -234,7 +243,7 @@ class SendState_NeedAmount implements SendState {
         final req = PreflightPayOfferRequest(
           cid: this.cid,
           offer: offer.string,
-          fallbackAmountSats: (offer.amountSats == null) ? amountSats : null,
+          fallbackAmountSats: requestedOfferAmountSats(offer, amountSats),
         );
 
         final result = await this.paymentService.preflightPayOffer(req: req);
@@ -436,9 +445,10 @@ class SendState_Preflighted implements SendState {
     final req = PayOfferRequest(
       cid: this.cid,
       offer: preflighted.offer.string,
-      fallbackAmountSats: (preflighted.offer.amountSats == null)
-          ? preflighted.amountSats
-          : null,
+      fallbackAmountSats: requestedOfferAmountSats(
+        preflighted.offer,
+        preflighted.amountSats,
+      ),
       note: note,
       payerNote: preflighted.payerNote,
     );

--- a/app/lib/route/wallet.dart
+++ b/app/lib/route/wallet.dart
@@ -398,6 +398,7 @@ class WalletPageState extends State<WalletPage> {
           featureFlags: this.widget.featureFlags,
           fiatRate: this.fiatRateService.fiatRate,
           settings: this.widget.settings,
+          provisionService: this.provisionService,
         ),
       ),
     );

--- a/app/lib/service/provision.dart
+++ b/app/lib/service/provision.dart
@@ -34,7 +34,6 @@ class ProvisionService {
     this._isProvisioning.value = true;
     final res = await Result.tryFfiAsync(() => this._app.provision());
     if (this.isDisposed) return;
-    this._isProvisioning.value = false;
 
     switch (res) {
       case Ok():
@@ -47,6 +46,8 @@ class ProvisionService {
         error("provision: err: ${err.message}");
         break;
     }
+
+    this._isProvisioning.value = false;
   }
 
   void wrapListener(void Function() listener) {

--- a/app/test/mocks/mock_send_payment_service.dart
+++ b/app/test/mocks/mock_send_payment_service.dart
@@ -35,6 +35,7 @@ class MockSendPaymentService implements SendPaymentService {
   FfiResult<PayOnchainResponse>? payOnchainResult;
   FfiResult<PayInvoiceResponse>? payInvoiceResult;
   FfiResult<PayOfferResponse>? payOfferResult;
+  PreflightPayOfferRequest? lastPreflightPayOfferRequest;
   PayOfferRequest? lastPayOfferRequest;
 
   /// Tracked method calls for verification in tests.
@@ -50,6 +51,7 @@ class MockSendPaymentService implements SendPaymentService {
     this.payOnchainResult = null;
     this.payInvoiceResult = null;
     this.payOfferResult = null;
+    this.lastPreflightPayOfferRequest = null;
     this.lastPayOfferRequest = null;
     this.calls.clear();
   }
@@ -86,6 +88,7 @@ class MockSendPaymentService implements SendPaymentService {
   Future<FfiResult<PreflightPayOfferResponse>> preflightPayOffer({
     required PreflightPayOfferRequest req,
   }) async {
+    this.lastPreflightPayOfferRequest = req;
     this.calls.add('preflightPayOffer(${req.offer})');
     return this.preflightPayOfferResult ??
         Err(const FfiError('preflightPayOffer not configured'));

--- a/app/test/receive_page_test.dart
+++ b/app/test/receive_page_test.dart
@@ -1,0 +1,104 @@
+import 'package:app_rs_dart/ffi/api.dart'
+    show
+        CreateInvoiceRequest,
+        CreateInvoiceResponse,
+        CreateOfferRequest,
+        CreateOfferResponse;
+import 'package:app_rs_dart/ffi/types.dart' show Invoice, Offer;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lexeapp/design_mode/mocks.dart' as mocks;
+import 'package:lexeapp/result.dart' show FfiError;
+import 'package:lexeapp/route/receive/page.dart' show ReceiveProvisionGate;
+import 'package:lexeapp/service/provision.dart' show ProvisionService;
+
+class _ProvisioningMockAppHandle extends mocks.MockAppHandle {
+  _ProvisioningMockAppHandle()
+    : super(
+        balance: mocks.balanceDefault,
+        payments: const [],
+        channels: const [],
+      );
+
+  static const address = "bcrt1q2nfxmhd4n3c8834pj72xagvyr9gl57n5r94fsl";
+
+  bool isProvisioned = false;
+  int preProvisionFailures = 0;
+
+  @override
+  Future<void> provision() async {
+    await Future<void>.delayed(const Duration(milliseconds: 10));
+    this.isProvisioned = true;
+  }
+
+  @override
+  Future<String> getAddress() async {
+    if (!this.isProvisioned) {
+      this.preProvisionFailures += 1;
+      throw const FfiError("App is not provisioned").toFfi();
+    }
+
+    return address;
+  }
+
+  @override
+  Future<CreateInvoiceResponse> createInvoice({
+    required CreateInvoiceRequest req,
+  }) async {
+    if (!this.isProvisioned) {
+      this.preProvisionFailures += 1;
+      throw const FfiError("App is not provisioned").toFfi();
+    }
+
+    final now = DateTime.now();
+    return CreateInvoiceResponse(
+      invoice: Invoice(
+        string: mocks.dummyInvoiceInboundPending01.invoice!.string,
+        createdAt: now.millisecondsSinceEpoch,
+        expiresAt: now
+            .add(Duration(seconds: req.expirySecs))
+            .millisecondsSinceEpoch,
+        amountSats: req.amountSats,
+        description: req.description,
+        payeePubkey: mocks.dummyInvoiceInboundPending01.invoice!.payeePubkey,
+      ),
+    );
+  }
+
+  @override
+  Future<CreateOfferResponse> createOffer({
+    required CreateOfferRequest req,
+  }) async {
+    if (!this.isProvisioned) {
+      this.preProvisionFailures += 1;
+      throw const FfiError("App is not provisioned").toFfi();
+    }
+
+    return CreateOfferResponse(
+      offer: Offer(
+        string: mocks.dummyOfferInboundPayment01.offer!.string,
+        expiresAt: null,
+        amountSats: req.amountSats,
+        description: req.description,
+      ),
+    );
+  }
+}
+
+void main() {
+  test(
+    "provision gate waits for provisioning before allowing fetches",
+    () async {
+      final app = _ProvisioningMockAppHandle();
+      final provisionService = ProvisionService(app: app);
+      final provisionGate = ReceiveProvisionGate();
+
+      final isProvisioned = await provisionGate.ensureProvisioned(
+        provisionService,
+      );
+
+      expect(isProvisioned, isTrue);
+      expect(app.preProvisionFailures, 0);
+      expect(app.isProvisioned, isTrue);
+    },
+  );
+}

--- a/app/test/send_state_test.dart
+++ b/app/test/send_state_test.dart
@@ -143,6 +143,64 @@ void main() {
       },
     );
 
+    test(
+      'resolveAndMaybePreflight keeps offers with minimum amounts on the amount page',
+      () async {
+        const offer = Offer(
+          string: testOffer,
+          embeddedAmountSats: 1000,
+          amountSats: 1000,
+        );
+        mockService.resolveBestResult = const Ok(PaymentMethod.offer(offer));
+
+        final state = SendState_NeedUri(
+          paymentService: mockService,
+          configNetwork: Network.mainnet,
+          balance: testBalance(),
+          cid: testCid(),
+          fiatRate: fiatRate,
+        );
+
+        final result = await state.resolveAndMaybePreflight(testOffer);
+
+        expect(result.isOk, true);
+        expect(result.ok, isA<SendState_NeedAmount>());
+        expect(mockService.calls, ['resolveBest($testOffer)']);
+      },
+    );
+
+    test(
+      'resolveAndMaybePreflight preflights immediately for BIP321 offer amounts',
+      () async {
+        const offer = Offer(string: testOffer, amountSats: 5000);
+        mockService.resolveBestResult = const Ok(PaymentMethod.offer(offer));
+        mockService.preflightPayOfferResult = const Ok(
+          PreflightPayOfferResponse(amountSats: 5000, feesSats: 5),
+        );
+
+        final state = SendState_NeedUri(
+          paymentService: mockService,
+          configNetwork: Network.mainnet,
+          balance: testBalance(),
+          cid: testCid(),
+          fiatRate: fiatRate,
+        );
+
+        final result = await state.resolveAndMaybePreflight(testOffer);
+
+        expect(result.isOk, true);
+        expect(result.ok, isA<SendState_Preflighted>());
+        expect(mockService.calls, [
+          'resolveBest($testOffer)',
+          'preflightPayOffer($testOffer)',
+        ]);
+        expect(
+          mockService.lastPreflightPayOfferRequest?.fallbackAmountSats,
+          5000,
+        );
+      },
+    );
+
     test('resolveAndMaybePreflight returns error for invalid URI', () async {
       mockService.resolveBestResult = const Err(
         FfiError('Invalid address format'),
@@ -244,6 +302,24 @@ void main() {
       expect(state.canPreflightImmediately(), 1000);
     });
 
+    test('canPreflightImmediately returns null for offers with amount', () {
+      const offer = Offer(
+        string: testOffer,
+        embeddedAmountSats: 1000,
+        amountSats: 1000,
+      );
+      final state = SendState_NeedAmount(
+        paymentService: mockService,
+        configNetwork: Network.mainnet,
+        balance: testBalance(),
+        cid: testCid(),
+        fiatRate: fiatRate,
+        paymentMethod: const PaymentMethod.offer(offer),
+      );
+
+      expect(state.canPreflightImmediately(), null);
+    });
+
     test('preflight succeeds for onchain payment', () async {
       const onchain = Onchain(
         address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
@@ -324,6 +400,37 @@ void main() {
       expect(mockService.calls, ['preflightPayOffer($testOffer)']);
     });
 
+    test(
+      'preflight uses the user-selected amount for offers with minimums',
+      () async {
+        const offer = Offer(
+          string: testOffer,
+          embeddedAmountSats: 1000,
+          amountSats: 1000,
+        );
+        mockService.preflightPayOfferResult = const Ok(
+          PreflightPayOfferResponse(amountSats: 3000, feesSats: 5),
+        );
+
+        final state = SendState_NeedAmount(
+          paymentService: mockService,
+          configNetwork: Network.mainnet,
+          balance: testBalance(),
+          cid: testCid(),
+          fiatRate: fiatRate,
+          paymentMethod: const PaymentMethod.offer(offer),
+        );
+
+        final result = await state.preflight(3000);
+
+        expect(result.isOk, true);
+        expect(
+          mockService.lastPreflightPayOfferRequest?.fallbackAmountSats,
+          3000,
+        );
+      },
+    );
+
     test('preflight returns error on failure', () async {
       const onchain = Onchain(
         address: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
@@ -399,6 +506,31 @@ void main() {
       expect(mockService.lastPayOfferRequest?.note, 'Offer payment');
       expect(mockService.lastPayOfferRequest?.payerNote, 'payer note');
     });
+
+    test(
+      'pay uses the user-selected amount for offers with minimums',
+      () async {
+        mockService.payOfferResult = Ok(
+          PayOfferResponse(index: PaymentCreatedIndex(field0: 'test-index')),
+        );
+
+        final state = _createPreflightedOffer(
+          mockService,
+          fiatRate,
+          payerNote: null,
+          offer: const Offer(
+            string: testOffer,
+            embeddedAmountSats: 1000,
+            amountSats: 1000,
+          ),
+        );
+
+        final result = await state.pay('Offer payment', null);
+
+        expect(result.isOk, true);
+        expect(mockService.lastPayOfferRequest?.fallbackAmountSats, 3000);
+      },
+    );
 
     test('pay returns error on failure', () async {
       mockService.payOnchainResult = const Err(FfiError('Transaction failed'));
@@ -525,6 +657,7 @@ SendState_Preflighted _createPreflightedOffer(
   MockSendPaymentService mockService,
   ValueNotifier<FiatRate?> fiatRate, {
   required String? payerNote,
+  Offer offer = const Offer(string: testOffer),
 }) {
   return SendState_Preflighted(
     paymentService: mockService,
@@ -533,7 +666,7 @@ SendState_Preflighted _createPreflightedOffer(
     cid: testCid(),
     fiatRate: fiatRate,
     preflightedPayment: PreflightedPayment_Offer(
-      offer: Offer(string: testOffer),
+      offer: offer,
       amountSats: 3000,
       preflight: PreflightPayOfferResponse(amountSats: 3000, feesSats: 5),
       payerNote: payerNote,

--- a/app_rs_dart/lib/ffi/types.dart
+++ b/app_rs_dart/lib/ffi/types.dart
@@ -316,6 +316,7 @@ sealed class Offer with _$Offer {
     required String string,
     String? description,
     int? expiresAt,
+    int? embeddedAmountSats,
     int? amountSats,
     String? payee,
     String? payeePubkey,

--- a/app_rs_dart/lib/ffi/types.freezed.dart
+++ b/app_rs_dart/lib/ffi/types.freezed.dart
@@ -391,22 +391,22 @@ String toString() {
 /// @nodoc
 mixin _$Offer {
 
- String get string; String? get description; int? get expiresAt; int? get amountSats; String? get payee; String? get payeePubkey;
+ String get string; String? get description; int? get expiresAt; int? get embeddedAmountSats; int? get amountSats; String? get payee; String? get payeePubkey;
 
 
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is Offer&&(identical(other.string, string) || other.string == string)&&(identical(other.description, description) || other.description == description)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.amountSats, amountSats) || other.amountSats == amountSats)&&(identical(other.payee, payee) || other.payee == payee)&&(identical(other.payeePubkey, payeePubkey) || other.payeePubkey == payeePubkey));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is Offer&&(identical(other.string, string) || other.string == string)&&(identical(other.description, description) || other.description == description)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.embeddedAmountSats, embeddedAmountSats) || other.embeddedAmountSats == embeddedAmountSats)&&(identical(other.amountSats, amountSats) || other.amountSats == amountSats)&&(identical(other.payee, payee) || other.payee == payee)&&(identical(other.payeePubkey, payeePubkey) || other.payeePubkey == payeePubkey));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,string,description,expiresAt,amountSats,payee,payeePubkey);
+int get hashCode => Object.hash(runtimeType,string,description,expiresAt,embeddedAmountSats,amountSats,payee,payeePubkey);
 
 @override
 String toString() {
-  return 'Offer(string: $string, description: $description, expiresAt: $expiresAt, amountSats: $amountSats, payee: $payee, payeePubkey: $payeePubkey)';
+  return 'Offer(string: $string, description: $description, expiresAt: $expiresAt, embeddedAmountSats: $embeddedAmountSats, amountSats: $amountSats, payee: $payee, payeePubkey: $payeePubkey)';
 }
 
 
@@ -420,12 +420,13 @@ String toString() {
 
 
 class _Offer implements Offer {
-  const _Offer({required this.string, this.description, this.expiresAt, this.amountSats, this.payee, this.payeePubkey});
+  const _Offer({required this.string, this.description, this.expiresAt, this.embeddedAmountSats, this.amountSats, this.payee, this.payeePubkey});
   
 
 @override final  String string;
 @override final  String? description;
 @override final  int? expiresAt;
+@override final  int? embeddedAmountSats;
 @override final  int? amountSats;
 @override final  String? payee;
 @override final  String? payeePubkey;
@@ -435,16 +436,16 @@ class _Offer implements Offer {
 
 @override
 bool operator ==(Object other) {
-  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Offer&&(identical(other.string, string) || other.string == string)&&(identical(other.description, description) || other.description == description)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.amountSats, amountSats) || other.amountSats == amountSats)&&(identical(other.payee, payee) || other.payee == payee)&&(identical(other.payeePubkey, payeePubkey) || other.payeePubkey == payeePubkey));
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _Offer&&(identical(other.string, string) || other.string == string)&&(identical(other.description, description) || other.description == description)&&(identical(other.expiresAt, expiresAt) || other.expiresAt == expiresAt)&&(identical(other.embeddedAmountSats, embeddedAmountSats) || other.embeddedAmountSats == embeddedAmountSats)&&(identical(other.amountSats, amountSats) || other.amountSats == amountSats)&&(identical(other.payee, payee) || other.payee == payee)&&(identical(other.payeePubkey, payeePubkey) || other.payeePubkey == payeePubkey));
 }
 
 
 @override
-int get hashCode => Object.hash(runtimeType,string,description,expiresAt,amountSats,payee,payeePubkey);
+int get hashCode => Object.hash(runtimeType,string,description,expiresAt,embeddedAmountSats,amountSats,payee,payeePubkey);
 
 @override
 String toString() {
-  return 'Offer(string: $string, description: $description, expiresAt: $expiresAt, amountSats: $amountSats, payee: $payee, payeePubkey: $payeePubkey)';
+  return 'Offer(string: $string, description: $description, expiresAt: $expiresAt, embeddedAmountSats: $embeddedAmountSats, amountSats: $amountSats, payee: $payee, payeePubkey: $payeePubkey)';
 }
 
 

--- a/app_rs_dart/lib/frb_generated.dart
+++ b/app_rs_dart/lib/frb_generated.dart
@@ -3995,15 +3995,16 @@ class AppRsApiImpl extends AppRsApiImplPlatform implements AppRsApi {
   Offer dco_decode_offer(dynamic raw) {
     // Codec=Dco (DartCObject based), see doc to use other codecs
     final arr = raw as List<dynamic>;
-    if (arr.length != 6)
-      throw Exception('unexpected arr length: expect 6 but see ${arr.length}');
+    if (arr.length != 7)
+      throw Exception('unexpected arr length: expect 7 but see ${arr.length}');
     return Offer(
       string: dco_decode_String(arr[0]),
       description: dco_decode_opt_String(arr[1]),
       expiresAt: dco_decode_opt_CastedPrimitive_i_64(arr[2]),
-      amountSats: dco_decode_opt_CastedPrimitive_u_64(arr[3]),
-      payee: dco_decode_opt_String(arr[4]),
-      payeePubkey: dco_decode_opt_String(arr[5]),
+      embeddedAmountSats: dco_decode_opt_CastedPrimitive_u_64(arr[3]),
+      amountSats: dco_decode_opt_CastedPrimitive_u_64(arr[4]),
+      payee: dco_decode_opt_String(arr[5]),
+      payeePubkey: dco_decode_opt_String(arr[6]),
     );
   }
 
@@ -5613,6 +5614,9 @@ class AppRsApiImpl extends AppRsApiImplPlatform implements AppRsApi {
     var var_string = sse_decode_String(deserializer);
     var var_description = sse_decode_opt_String(deserializer);
     var var_expiresAt = sse_decode_opt_CastedPrimitive_i_64(deserializer);
+    var var_embeddedAmountSats = sse_decode_opt_CastedPrimitive_u_64(
+      deserializer,
+    );
     var var_amountSats = sse_decode_opt_CastedPrimitive_u_64(deserializer);
     var var_payee = sse_decode_opt_String(deserializer);
     var var_payeePubkey = sse_decode_opt_String(deserializer);
@@ -5620,6 +5624,7 @@ class AppRsApiImpl extends AppRsApiImplPlatform implements AppRsApi {
       string: var_string,
       description: var_description,
       expiresAt: var_expiresAt,
+      embeddedAmountSats: var_embeddedAmountSats,
       amountSats: var_amountSats,
       payee: var_payee,
       payeePubkey: var_payeePubkey,
@@ -7308,6 +7313,7 @@ class AppRsApiImpl extends AppRsApiImplPlatform implements AppRsApi {
     sse_encode_String(self.string, serializer);
     sse_encode_opt_String(self.description, serializer);
     sse_encode_opt_CastedPrimitive_i_64(self.expiresAt, serializer);
+    sse_encode_opt_CastedPrimitive_u_64(self.embeddedAmountSats, serializer);
     sse_encode_opt_CastedPrimitive_u_64(self.amountSats, serializer);
     sse_encode_opt_String(self.payee, serializer);
     sse_encode_opt_String(self.payeePubkey, serializer);

--- a/lexe-api-core/src/models/command.rs
+++ b/lexe-api-core/src/models/command.rs
@@ -403,8 +403,10 @@ pub struct PreflightPayOfferRequest {
     pub cid: ClientPaymentId,
     /// The offer we want to pay.
     pub offer: Offer,
-    /// Specifies the amount we will pay if the offer to be paid is
-    /// amountless. This field must be [`Some`] for amountless offers.
+    /// The payer-selected amount for this payment.
+    ///
+    /// This field must be [`Some`] for amountless offers, and may also be used
+    /// to pay more than an offer's encoded minimum amount.
     pub fallback_amount: Option<Amount>,
 }
 
@@ -437,8 +439,10 @@ pub struct PayOfferRequest {
     pub cid: ClientPaymentId,
     /// The offer we want to pay.
     pub offer: Offer,
-    /// Specifies the amount we will pay if the offer to be paid is
-    /// amountless. This field must be [`Some`] for amountless offers.
+    /// The payer-selected amount for this payment.
+    ///
+    /// This field must be [`Some`] for amountless offers, and may also be used
+    /// to pay more than an offer's encoded minimum amount.
     pub fallback_amount: Option<Amount>,
     /// An optional personal note for this payment, useful if the
     /// receiver-provided description is insufficient.

--- a/lexe-ln/src/command.rs
+++ b/lexe-ln/src/command.rs
@@ -1481,11 +1481,10 @@ where
         None
     };
     // TODO(phlip9): actual_amount = amount * quantity
-    // TODO(phlip9): support over-paying offers? `offer_amount` is actually a
-    //               _minimum_ amount and the spec allows over-paying.
-    // Compute the amount; handle amountless offers.
+    // Compute the amount; handle amountless offers and allow paying more than
+    // the offer's encoded minimum amount.
     let amount =
-        validate::pay_amount("offers", offer.amount(), req.fallback_amount)?;
+        validate::pay_offer_amount(offer.amount(), req.fallback_amount)?;
 
     // Compute Lightning balances
     let channels = channel_manager.list_channels();
@@ -1584,6 +1583,29 @@ mod validate {
         amount.or(fallback_amount).with_context(|| {
             format!("Missing fallback amount for amountless {kind}")
         })
+    }
+
+    /// Get the final amount we should pay for an offer.
+    ///
+    /// BOLT12 offer amounts are minimums, not exact amounts, so callers may
+    /// request a larger payment amount as long as it meets that minimum.
+    pub(super) fn pay_offer_amount(
+        offer_amount: Option<Amount>,
+        requested_amount: Option<Amount>,
+    ) -> anyhow::Result<Amount> {
+        match (offer_amount, requested_amount) {
+            (Some(minimum_amount), Some(requested_amount)) => {
+                ensure!(
+                    requested_amount >= minimum_amount,
+                    "Requested offer amount is less than the offer minimum"
+                );
+                Ok(requested_amount)
+            }
+            (Some(minimum_amount), None) => Ok(minimum_amount),
+            (None, Some(requested_amount)) => Ok(requested_amount),
+            (None, None) =>
+                Err(anyhow!("Missing fallback amount for amountless offers")),
+        }
     }
 
     /// Check that the user has at least one usable channel.
@@ -2016,5 +2038,36 @@ mod test {
                 result.unwrap();
             }
         });
+    }
+
+    #[test]
+    fn pay_offer_amount_prefers_requested_amount_when_it_exceeds_minimum() {
+        let minimum_amount = Amount::from_sats_u32(1_000);
+        let requested_amount = Amount::from_sats_u32(3_000);
+
+        let amount = validate::pay_offer_amount(
+            Some(minimum_amount),
+            Some(requested_amount),
+        )
+        .unwrap();
+
+        assert_eq!(amount, requested_amount);
+    }
+
+    #[test]
+    fn pay_offer_amount_rejects_requested_amount_below_minimum() {
+        let minimum_amount = Amount::from_sats_u32(1_000);
+        let requested_amount = Amount::from_sats_u32(999);
+
+        let err = validate::pay_offer_amount(
+            Some(minimum_amount),
+            Some(requested_amount),
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "Requested offer amount is less than the offer minimum"
+        );
     }
 }


### PR DESCRIPTION
## Reason
Breez's BOLT12 receive flow encodes the minimum receivable amount into the offer. Lexe was treating that embedded minimum as a fixed amount, which skipped the amount-entry UX and left users no way to send more than the minimum when opening an offer. This change aligns the send flow with the actual offer semantics: the embedded amount is a minimum, not an exact payment amount.

## Summary
- keep BOLT12 offers with embedded minimums on the amount screen and prefill that minimum
- distinguish embedded offer minimums from BIP321 fallback amounts in the app FFI model
- allow offer preflight/payment requests to send a payer-selected amount above the encoded minimum while rejecting amounts below it

## Review Notes
- self-review caught and fixed a regression where BIP321 URI amounts on amountless offers could be mistaken for embedded offer minimums
- scoped commit excludes unrelated local worktree changes already present in this checkout

## Test Plan
- `nix develop .#app-rs-codegen -c bash -lc 'cargo rustc --lib --crate-type=cdylib -p app-rs'`
- `nix develop .#app-rs-codegen -c bash -lc 'cargo test -p lexe-ln pay_offer_amount'`
- `nix develop .#app-rs-codegen -c bash -lc 'cd app && flutter test test/send_state_test.dart'`
